### PR TITLE
Fix sign-in/up button overlap with keyboard

### DIFF
--- a/app/(app)/sign-in.tsx
+++ b/app/(app)/sign-in.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { ActivityIndicator, View } from "react-native";
+import { ActivityIndicator, View, KeyboardAvoidingView, Platform } from "react-native";
 import * as z from "zod";
 
 import { SafeAreaView } from "@/components/safe-area-view";
@@ -39,8 +39,13 @@ export default function SignIn() {
 		}
 	}
 
-	return (
-		<SafeAreaView className="flex-1 bg-background p-4" edges={["bottom"]}>
+        return (
+                <KeyboardAvoidingView
+                        behavior={Platform.OS === "ios" ? "padding" : undefined}
+                        keyboardVerticalOffset={100}
+                        style={{ flex: 1 }}
+                >
+                        <SafeAreaView className="flex-1 bg-background p-4" edges={["bottom"]}>
 			<View className="flex-1 gap-4 web:m-4">
 				<H1 className="self-start ">Sign In</H1>
 				<Form {...form}>
@@ -89,7 +94,8 @@ export default function SignIn() {
 				) : (
 					<Text>Sign In</Text>
 				)}
-			</Button>
-		</SafeAreaView>
-	);
+                        </Button>
+                </SafeAreaView>
+                </KeyboardAvoidingView>
+        );
 }

--- a/app/(app)/sign-up.tsx
+++ b/app/(app)/sign-up.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { ActivityIndicator, View } from "react-native";
+import { ActivityIndicator, View, KeyboardAvoidingView, Platform } from "react-native";
 import * as z from "zod";
 
 import { SafeAreaView } from "@/components/safe-area-view";
@@ -59,8 +59,13 @@ export default function SignUp() {
 		}
 	}
 
-	return (
-		<SafeAreaView className="flex-1 bg-background p-4" edges={["bottom"]}>
+        return (
+                <KeyboardAvoidingView
+                        behavior={Platform.OS === "ios" ? "padding" : undefined}
+                        keyboardVerticalOffset={100}
+                        style={{ flex: 1 }}
+                >
+                        <SafeAreaView className="flex-1 bg-background p-4" edges={["bottom"]}>
 			<View className="flex-1 gap-4 web:m-4">
 				<H1 className="self-start">Sign Up</H1>
 
@@ -124,7 +129,8 @@ export default function SignUp() {
 				) : (
 					<Text>Sign Up</Text>
 				)}
-			</Button>
-		</SafeAreaView>
-	);
+                        </Button>
+                </SafeAreaView>
+                </KeyboardAvoidingView>
+        );
 }


### PR DESCRIPTION
## Summary
- avoid keyboard overlay on auth screens by wrapping each screen in a KeyboardAvoidingView

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401b191c948326be77c882c4ad28b5